### PR TITLE
fix(scim): POST uses ComputeMD5() on final representation and syncs m…

### DIFF
--- a/src/Looplex.Foundation/SCIMv2/Entities/ServiceProviderConfiguration.cs
+++ b/src/Looplex.Foundation/SCIMv2/Entities/ServiceProviderConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 using Looplex.Foundation.Entities;
 
@@ -66,7 +67,9 @@ public class ServiceProviderConfiguration : Actor
   /// </summary>
   public Sort? Sort { get; set; }
 
-  [JsonIgnore] public virtual List<ResourceMap> Map { get; private set; } = new();
+  [Newtonsoft.Json.JsonIgnore]
+  [System.Text.Json.Serialization.JsonIgnore]
+  public virtual List<ResourceMap> Map { get; private set; } = new();
 }
 
 public class AuthenticationScheme


### PR DESCRIPTION
POST uses ComputeMD5() on final representation and syncs meta.version/ETag; 

Unifies weak ETag calculation from the final SCIM body; keeps Content-Type application/scim+json;